### PR TITLE
General Sidecar Test Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ docker run -d --rm --name substrate-api-sidecar \
 
 ## Run Sidecar as an NPM Package
 
-Please refer to the [Moonbeam Documentation](https://docs.moonbeam.network/builders/substrate/libraries/sidecar/#installing-and-running-substrate-api-sidecar){target=\_blank}.
+Please refer to the [Moonbeam Documentation](https://docs.moonbeam.network/builders/substrate/libraries/sidecar/#installing-and-running-substrate-api-sidecar).
 
 ## Sidecar tests
 
@@ -39,7 +39,7 @@ Launch tests with Python
 ```bash
 python -m venv test-env
 . ./test-env/bin/activate
-python -m pip install requests web3 substrate-interface
+python -m pip install -r requirements.txt
 # moonbase-alpha|moonriver|moonbeam
 python monitor.py --network moonbase-alpha --log=INFO
 ```

--- a/monitor.py
+++ b/monitor.py
@@ -4,7 +4,7 @@ import requests, random, time, logging, argparse, sys
 from web3 import Web3
 from substrateinterface import SubstrateInterface
 
-num_blocks_to_perform_content_test = 5
+num_blocks_to_perform_content_test = 10
 
 def parse_arguments():
   parser = argparse.ArgumentParser(description="Script to test a Sidecar instance")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 requests==2.28.1
 web3==5.31.2
-substrate-interface==1.4.2
+substrate-interface==1.7.11


### PR DESCRIPTION
Bumps the substrate-interface package version (to fix an issue with an incompatible dependency), bumps the number of blocks to test to 10.