### PR TITLE
updated requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 requests==2.28.1
-web3==5.31.2
+web3>=6.11
+eth-abi>=5.0.1
+parsimonious>=0.10.0
 substrate-interface==1.7.11


### PR DESCRIPTION
When I tried running the tests using python 3.11 I got an error related to a dependency version mismatch
The updated requirements file fixes this issue